### PR TITLE
TNDO-2845 Introduce MI workflow on master push

### DIFF
--- a/.github/workflows/mi.yml
+++ b/.github/workflows/mi.yml
@@ -1,0 +1,20 @@
+name: MI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  mi:
+    name: Update Microservice Intelligence Workspace
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get credentials
+        uses: leanix/secrets-action@master
+        with:
+          secret-store-credentials: ${{ secrets.INJECTED_SECRET_STORE_CREDENTIALS }}
+
+      - name: MI Update
+        uses: leanix/microservice-intelligence-action@master

--- a/.github/workflows/mi.yml
+++ b/.github/workflows/mi.yml
@@ -3,7 +3,7 @@ name: MI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   mi:


### PR DESCRIPTION
This workflow triggers when the reporting lib is released in
pathfinder-web as the new updates docs are pushed to master. As the
reporting-lib itself is part of pathfinder-web this repo is used as
representative.