### PR TITLE
CMP-303: Playwright MCP replaces Chrome DevTools MCP in AI Agent Guide

### DIFF
--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -119,7 +119,7 @@ Use Playwright MCP to verify reports render without errors. This prevents AI-gen
 
 **Setup:**
 
-Playwright MCP and LeanIX MCP Server are **pre-configured** in scaffolded projects (`.vscode/mcp.json` for GitHub Copilot, `.mcp.json` for Claude Code). Playwright MCP works with Chrome, Microsoft Edge, Firefox, and WebKit — no separate browser installation required on most systems. Configuration files contain actual credentials and are automatically gitignored.
+Playwright MCP and LeanIX MCP Server are **pre-configured** in scaffolded projects (`.vscode/mcp.json` for GitHub Copilot, `.mcp.json` for Claude Code). The scaffold selects a browser at install time — system Edge on Windows, system Chrome on Mac/Linux when installed, with Playwright's bundled Chromium as a fallback. Configuration files contain actual credentials and are automatically gitignored.
 
 ---
 

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -89,11 +89,11 @@ Run `npm run dev` to get a **LeanIX-hosted development URL**. Copy the complete 
 In the main folder there is the `lxr.json` which contains an API token for the connected workspace. Do not attempt to access it.
 If the commands like `npm run dev` are not working, the error might be here.
 
-### Verifying Report Rendering (Chrome DevTools MCP)
+### Verifying Report Rendering (Playwright MCP)
 
 **After writing code, verify the report renders before declaring success.**
 
-Use Chrome DevTools MCP to verify reports render without errors. This prevents AI-generated reports from showing blank screens due to small errors (wrong field names, incorrect data access).
+Use Playwright MCP to verify reports render without errors. This prevents AI-generated reports from showing blank screens due to small errors (wrong field names, incorrect data access).
 
 **When to verify:**
 
@@ -109,6 +109,8 @@ Use Chrome DevTools MCP to verify reports render without errors. This prevents A
 4. **Take screenshot** - Verify content displays (not a blank screen)
 5. **Fix if needed** - Correct errors, save, and re-verify
 
+**Scope:** One pass is enough — navigate, scan the console, take one screenshot to confirm something renders. The goal is to catch fully broken reports (blank screen, crash, missing data) before handing off. Deep functional testing is the developer's responsibility.
+
 **Common issues to catch:**
 
 - JavaScript errors (undefined properties, null references)
@@ -117,7 +119,7 @@ Use Chrome DevTools MCP to verify reports render without errors. This prevents A
 
 **Setup:**
 
-Chrome DevTools MCP and LeanIX MCP Server are **pre-configured** in scaffolded projects (`.vscode/mcp.json` for GitHub Copilot, `.mcp.json` for Claude Code). Configuration files contain actual credentials and are automatically gitignored.
+Playwright MCP and LeanIX MCP Server are **pre-configured** in scaffolded projects (`.vscode/mcp.json` for GitHub Copilot, `.mcp.json` for Claude Code). Playwright MCP works with Chrome, Microsoft Edge, Firefox, and WebKit — no separate browser installation required on most systems. Configuration files contain actual credentials and are automatically gitignored.
 
 ---
 
@@ -669,7 +671,7 @@ Once your report is ready, upload it to your LeanIX workspace:
 Before uploading your report:
 
 - **Schema verified** - Used LeanIX MCP tools to verify all fact sheet types and field names
-- **Rendering verified** - Chrome DevTools MCP verification passed (no console errors or blank screens)
+- **Rendering verified** - Playwright MCP verification passed (no console errors or blank screens)
 - **Empty states handled** - Code handles null/undefined/empty data gracefully
 - **No hardcoded values** - All chart data, lifecycle phases, and field values derived dynamically
 - **No assumptions** - Asked user for clarification on any uncertain business logic, classifications, or calculations
@@ -682,7 +684,7 @@ Before uploading your report:
 - **View model colors** - Colors all technical fact sheet types, fields, and values through workspace colors
 - **Translations** - Translates all technical keys (fact sheet types, fields, relations, values) to user-friendly display names
 - **Linting passes** - `npm run lint` succeeds
-- **Browser tested** - `npm run dev` tested in browser with real data (or Chrome DevTools MCP verification passed)
+- **Browser tested** - `npm run dev` tested in browser with real data (or Playwright MCP verification passed)
 
 ---
 


### PR DESCRIPTION
`chrome-devtools-mcp` is Chrome-only. Most LeanIX customers use Edge — on systems without Chrome the AI can't verify report rendering before declaring success.

## Changes
- Rename section: "Verifying Report Rendering (Chrome DevTools MCP)" → "…(Playwright MCP)"
- Update setup note: works with Chrome, Edge, Firefox, WebKit — no browser install needed
- Add Scope note: one pass/screenshot is enough; catching blank screens and crashes is the goal — deep functional testing is the developer's responsibility
- Update two pre-upload checklist entries

## Notes
- Confluence "Setting Up the Vibe Coding Environment" still references Chrome DevTools MCP — needs a manual update after merge.
- Companion PR (scaffolding): SAP/leanix-custom-report-tools#102

## Testing
<img width="959" height="133" alt="image" src="https://github.com/user-attachments/assets/965e280f-d965-4ae9-af18-e274e1ebe962" />
<img width="735" height="250" alt="image" src="https://github.com/user-attachments/assets/c4b3ad60-19f4-44f6-9a30-2fc38dcc1272" />
