### PR TITLE
DEVX-773: (AI GENERATED) add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ jobs:
   notify-release:
     name: Notify release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Get release
         id: get_release


### PR DESCRIPTION
Adds minimal required `permissions:` blocks to workflow jobs that were missing them.

**Motivation:** Explicit permissions follow the principle of least privilege and prevent accidental access escalation.

**Note:** Please review this PR carefully, as it was generated with assistance from AI. This is only a migration helper, so ensure you thoroughly evaluate the changes before merging it on your own.

**Timeline:**
   _From June 1_
   Default switches to read-only org-wide. Repos can still override the setting for their own workflows — giving teams a grace week to finish up.
   _From June 8_
   Read-only is enforced via org policy. No more per-repo override.

**Changes:**
- `release.yml`: added `permissions` block to `notify-release` job

**Permissions added:**
- `notify-release` job: `contents: read`
  - No specific action rules matched (no checkout, docker, gradle, etc.). Minimal `contents: read` applied as the safe default — ensures the job retains a read token after GitHub switches to read-only org defaults.