### PR TITLE
CMP-357+406 Update `AI_AGENT_GUIDE.md` for new report identity model and `README` tooling references

### DIFF
--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -196,7 +196,7 @@ In `package.json`:
 
 ### Package name rules
 
-Package name may only contain lowercase letters (`a-z`), digits (`0-9`), dots (`.`), underscores (`_`), and minus (`-`).
+Package name may only contain lowercase letters (`a-z`), digits (`0-9`), dots (`.`), hyphens (`-`), underscores (`_`), or a scoped name (e.g. `@scope/name`).
 
 ---
 

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -119,7 +119,7 @@ Use Playwright MCP to verify reports render without errors. This prevents AI-gen
 
 **Setup:**
 
-Playwright MCP and LeanIX MCP Server are **pre-configured** in scaffolded projects (`.vscode/mcp.json` for GitHub Copilot, `.mcp.json` for Claude Code). The scaffold selects a browser at install time — system Edge on Windows, system Chrome on Mac/Linux when installed, with Playwright's bundled Chromium as a fallback. Configuration files contain actual credentials and are automatically gitignored.
+Playwright MCP and LeanIX MCP Server are **pre-configured** in created projects (`.vscode/mcp.json` for GitHub Copilot, `.mcp.json` for Claude Code). The creation tool selects a browser at install time — system Edge on Windows, system Chrome on Mac/Linux when installed, with Playwright's bundled Chromium as a fallback. Configuration files contain actual credentials and are automatically gitignored.
 
 ---
 

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -656,7 +656,11 @@ Translation methods automatically respect the user's current language setting. W
 
 ## Uploading to LeanIX
 
-> **Identity notice:** The `name` field in `package.json` is the report identity. Uploading the same package name + version twice to the same workspace will be rejected. Always increment `version` before re-uploading.
+> **Identity notice:** The `name` and `version` fields in `package.json` identify a report upload. Uploading the same package name + version to the same workspace is subject to these rules:
+
+- If the existing version is still being processed (`QUEUED`, `SCANNING` or `BUILDING`), the upload is rejected with HTTP 409. Wait for processing to finish, then try again.
+- If the existing version is in a terminal failed state (`FAILED`, `VULNERABLE`, or `REVOKED`), the upload succeeds and the old version is automatically replaced.
+- If the existing version succeeded, increment version in package.json before re-uploading.
 
 Once your report is ready, upload it to your LeanIX workspace:
 

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -185,9 +185,8 @@ When implementing calculations, classifications, scoring, or any logic NOT defin
 
 In `package.json`:
 
-- `name`: Project/repository name
+- `name`: Package name, the report identity — used together with `version` to uniquely identify a report in a workspace
 - `leanixReport.title`: Report title displayed in LeanIX
-- `leanixReport.id`: Report ID used to identify that two uploads are the same report
 - `leanixReport.description`
 - `leanixReport.author`
 
@@ -195,9 +194,9 @@ In `package.json`:
 
 - `leanixReport.aiAssisted`: Always set to `true`. If the field does not exist, create it.
 
-### Report ID Rules
+### Package name rules
 
-Report IDs may only contain lowercase letters (`a-z`), digits (`0-9`), dots (`.`), and underscores (`_`), and must not end with a dot.
+Package name may only contain lowercase letters (`a-z`), digits (`0-9`), dots (`.`), underscores (`_`), and minus (`-`).
 
 ---
 
@@ -656,6 +655,8 @@ Translation methods automatically respect the user's current language setting. W
 ---
 
 ## Uploading to LeanIX
+
+> **Identity notice:** The `name` field in `package.json` is the report identity. Uploading the same package name + version twice to the same workspace will be rejected. Always increment `version` before re-uploading.
 
 Once your report is ready, upload it to your LeanIX workspace:
 

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -188,8 +188,7 @@ In `package.json`:
 - `name`: Package name, like an npm package name. Only one version can be active in a workspace at a time - the active version can be changed by any user with the required permissions.
 - `version`: The version of the report. Together with `name`, uniquely identifies a release - bump this on every upload to avoid conflicts with existing versions.
 - `leanixReport.title`: Report title displayed in LeanIX
-- `leanixReport.description`
-- `leanixReport.author`
+- `leanixReport.description`: Report description displayed in LeanIX
 
 **You MUST always set or override the following:**
 

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -185,7 +185,8 @@ When implementing calculations, classifications, scoring, or any logic NOT defin
 
 In `package.json`:
 
-- `name`: Package name, the report identity — used together with `version` to uniquely identify a report in a workspace
+- `name`: Package name, like an npm package name. Only one version can be active in a workspace at a time - the active version can be changed by any user with the required permissions.
+- `version`: The version of the report. Together with `name`, uniquely identifies a release - bump this on every upload to avoid conflicts with existing versions.
 - `leanixReport.title`: Report title displayed in LeanIX
 - `leanixReport.description`
 - `leanixReport.author`

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 [![npm version](https://badge.fury.io/js/%40leanix%2Freporting.svg)](https://badge.fury.io/js/%40leanix%2Freporting)
 
-This library allows you to develop your own custom reports for LeanIX EAM Tool (https://www.leanix.net).
-We also provide a command line interface (CLI) that helps you to develop, test and upload your reports easily, see https://github.com/leanix/leanix-reporting-cli.
+This library allows you to develop your own custom reports for SAP LeanIX Enterprise Architecture Management.
+To scaffold, develop, and deploy custom reports, use the [SAP LeanIX custom report tools](https://github.com/SAP/leanix-custom-report-tools/).
+
+For official documentation, see the [Custom Reports](https://help.sap.com/docs/leanix/ea/custom-reports) and [Reporting Library and Custom Report Tools](https://help.sap.com/docs/leanix/ea/reporting-framework-and-cli) pages on the SAP Help Portal.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ https://leanix.github.io/leanix-reporting/
 
 Sometimes its easier to look at a few code examples than read through lines of documentation. Therefore we provide some snippets with code examples in the `examples` folder.
 
-## Basic concept of the LeanIX reporting framework
+## Basic concept of the SAP LeanIX reporting framework
 
-A report for LeanIX consists of HTML, JavaScript and CSS files, which are loaded into an iframe inside of the application. The report which is running within the iframe and the host application that contains the iframe communicate via a predefined set of messages (see: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage).
+A report for SAP LeanIX consists of HTML, JavaScript and CSS files, which are loaded into an iframe inside of the application. The report which is running within the iframe and the host application that contains the iframe communicate via a predefined set of messages (see: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage).
 
 As a report developer you do not have to know about the messages. This library takes care of the communication with the host application and provides a simple API that you can use to request data, send commands to the host application or be informed about events happening outside of your report.
 
@@ -87,7 +87,7 @@ As a report developer you do not have to know about the messages. This library t
 
 ### Config object
 
-The config object which has to be passed to `lx.ready()` acts as an interface between your report code and the reporting library. It allows you to define the requirements for your report, such as which data you want to fetch from LeanIX backend. In addition to that you have to register callback functions in the config object, which are called by the reporting library once certain events occur (for example when data has been fetched from the backend).
+The config object which has to be passed to `lx.ready()` acts as an interface between your report code and the reporting library. It allows you to define the requirements for your report, such as which data you want to fetch from SAP LeanIX backend. In addition to that you have to register callback functions in the config object, which are called by the reporting library once certain events occur (for example when data has been fetched from the backend).
 
 You can find the interface definition of the config object here: https://leanix.github.io/leanix-reporting/interfaces/lxr.ReportConfiguration.html
 


### PR DESCRIPTION
## Summary
### CMP-357
- Replaces `leanixReport.id` with `name` (package name) as the report identity field, adds package name validation rules, and removes the stale "Report ID Rules" section
- Adds an identity notice to the upload section: same package name + version cannot be uploaded twice to the same workspace
- Renames scaffolding to creation throughout

### CMP-406
- Updates `README` to reference the new [SAP LeanIX custom report tools](https://github.com/SAP/leanix-custom-report-tools/) and adds links to the SAP Help Portal documentation
- Replaces "LeanIX" with "SAP LeanIX" throughout `README`