### PR TITLE
CMP-462 Document reportViewFactSheetType in AI Agent Guide

### DIFF
--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -249,6 +249,7 @@ This implicit filtering happens automatically and can cause **incomplete data** 
 To show **all fact sheets** in a faceted report (including `DRAFT` and `REJECTED`), explicitly set `defaultFilters` with an **empty `keys` array**:
 
 ```typescript
+reportViewFactSheetType: "Initiative",
 facets: [
   {
     key: "initiatives",
@@ -309,6 +310,7 @@ A loading spinner is automatically displayed when the facets fetch data.
 class MyReport {
   createConfig(): lxr.ReportConfiguration {
     return {
+      reportViewFactSheetType: "Application",
       facets: [
         {
           key: "main",
@@ -488,6 +490,15 @@ const legendItems = Object.keys(fieldMeta?.values || {}).map((key) => ({
 }));
 // If your data includes null/undefined/n/a values that aren't in field metadata, add them to the legend manually with label 'n/a' and bgColor '#555555'
 lx.showLegend(legendItems);
+```
+
+**Widget view legend type badge:** When a report is rendered as a widget (in LeanIX dashboards, presentation slides, or HTML iframe exports), the legend header shows a fact sheet type icon and name (e.g. "A Application"). Without `reportViewFactSheetType`, it falls back to a generic "Fact Sheet" label. Always set it in `lx.ready()` to show the correct type:
+
+```typescript
+lx.ready({
+  reportViewFactSheetType: 'Application', // controls the type badge in widget legend header
+  facets: [ ... ]
+});
 ```
 
 There are many more UI components in `lxr.LxCustomReportLib`.


### PR DESCRIPTION
## Summary

Documents the `reportViewFactSheetType` option in the AI Agent Guide so AI-generated custom reports render the correct fact sheet type badge (e.g. "A Application") in the widget legend header instead of falling back to the generic "F Fact Sheet" label.

## Context

When a custom report is rendered as a widget — in LeanIX dashboards, presentation slides, or HTML iframe exports — the framework displays a legend header with a fact sheet type icon and name. This is driven by `reportViewFactSheetType` on the `ReportConfiguration` passed to `lx.ready()`. Without it, the legend shows a generic "Fact Sheet" label, which looks wrong next to out-of-the-box reports that show the proper type badge.

The option was not previously mentioned anywhere in the guide, so AI agents generating custom reports would consistently produce reports missing this configuration.

## Changes

- Added a new **Widget view legend type badge** section under UI Components explaining what `reportViewFactSheetType` does and when to set it
- Clarified the distinction between `reportViewFactSheetType` (widget legend header label) and `fixedFactSheetType` (facet data type filter)
- Added `reportViewFactSheetType` to the `createConfig()` code example in the Facets pattern section
- Added `reportViewFactSheetType` to the `defaultFilters` example under Implicit Filtering of Drafts

## Testing

Verified in a real custom report that adding `reportViewFactSheetType: 'Application'` correctly renders the "A Application" badge in the LeanIX dashboard legend header (replacing the generic "F Fact Sheet" fallback).

Before
<img width="1624" height="718" alt="image" src="https://github.com/user-attachments/assets/ec8b550e-ceb3-435b-ac52-593d15e5cf29" />
After
<img width="1898" height="1043" alt="image" src="https://github.com/user-attachments/assets/ec2901d3-92cc-41f8-919a-5001913739b8" />
